### PR TITLE
feat: add docker support to make menuconfig

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -29,4 +29,6 @@ source "lib/Kconfig"
 
 source "lib/Kconfig.debug"
 
+source "docker_support/Kconfig"
+
 source "Documentation/Kconfig"

--- a/docker_support/Kconfig
+++ b/docker_support/Kconfig
@@ -1,0 +1,86 @@
+menu "Docker Support"
+
+config DOCKER
+	bool "Docker support"
+	default n
+	help
+		Enable options required for Docker.
+
+	select PROC_PID_CPUSET
+	select NET
+	select NETDEVICES
+	select NET_CORE
+	select INET
+	select IPV6
+	select NET_L3_MASTER_DEV
+	select NETFILTER
+	select NETFILTER_XT_MATCH_IPVS
+	select NETFILTER_ADVANCED
+	select NF_CONNTRACK
+	select NETFILTER_XTABLES
+	select NF_CONNMARK_IPV4
+	select IP_NF_IPTABLES
+	select NF_NAT_MASQUERADE_IPV4
+	select IP_NF_NAT
+	select NET_SCHED
+
+	select MD
+	select TTY
+	select UNIX98_PTYS
+    select BPF_SYSCALL
+	select NAMESPACES
+	select NET_NS
+	select PID_NS
+	select IPC_NS
+	select UTS_NS
+	select CGROUPS
+	select CGROUP_CPUACCT
+	select CGROUP_DEVICE
+	select CGROUP_FREEZER
+	select CGROUP_SCHED
+	select CGROUP_BPF
+	select CGROUP_PIDS
+	select CGROUP_HUGETLB
+	select CGROUP_NET_PRIO
+	select CGROUP_NET_CLASSID
+	select NET_CLS_CGROUP
+	select CPUSETS
+	select MEMCG
+	select KEYS
+	select VETH
+	select BRIDGE
+	select BRIDGE_NETFILTER
+	select NF_NAT_IPV4
+	select IP_NF_FILTER
+	select IP_NF_TARGET_MASQUERADE
+	select NETFILTER_XT_MATCH_ADDRTYPE
+	select NETFILTER_XT_MATCH_CONNTRACK
+	select NF_NAT
+	select NF_NAT_NEEDED
+	select POSIX_MQUEUE
+	select USER_NS
+	select SECCOMP
+	select BLK_DEV_THROTTLING
+	select CFQ_GROUP_IOSCHED
+	select FAIR_GROUP_SCHED
+	select RT_GROUP_SCHED
+	select IP_VS
+	select IP_VS_PROTO_TCP
+	select IP_VS_PROTO_UDP
+	select IP_VS_NFCT
+	select VXLAN
+	select IPVLAN
+	select MACVLAN
+	select DUMMY
+	select DEVPTS_MULTIPLE_INSTANCES
+	select MEMCG_KMEM
+	select BLK_DEV_DM
+	select DM_THIN_PROVISIONING
+	select EXT4_FS
+	select EXT4_FS_POSIX_ACL
+	select EXT4_FS_SECURITY
+	select OVERLAY_FS
+	select EXT4_FS_SECURITY
+	select EXT4_FS_POSIX_ACL
+
+endmenu


### PR DESCRIPTION
Here are the flags we need to add to have full docker support in the ps4 kernel.

I will try to add more optional flags later.

This commit should be working for the other kernel too.

got inspired by @grilix's work on how to split the config.

closes #2 